### PR TITLE
fix : 调整android 端的sdk引入方式为 : api

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -90,7 +90,7 @@ kapt {
     }
 }
 dependencies {
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.finogeeks.lib:finapplet:2.38.9'
-    implementation 'com.finogeeks.mop:plugins:2.38.9'
+    api fileTree(include: ['*.jar'], dir: 'libs')
+    api 'com.finogeeks.lib:finapplet:2.38.9'
+    api 'com.finogeeks.mop:plugins:2.38.9'
 }


### PR DESCRIPTION
复杂工程下，确保其它模块可以引入